### PR TITLE
Adds http and external data sources and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# terraform-bitbucket-ip-addresses
-Provides a way to get the published whitelist IPv4 and IPv6 addresses for Bitbucket.
+# Bitbucket Whitelist IP Addresses
+
+This module provides both an IPv4 and IPv6 list of IP Addresses from Bitbucket, useful for whitelisting and security
+groups. In order to use this module, you must have both `bash` and `jq` installed on the system running Terraform.
+
+For a JSON list of these ip addresses, see [here](https://ip-ranges.atlassian.com/).
+
+### Installing JQ
+
+This module uses `jq` for parsing the JSON response from Bitbucket's ip-range endpoint.  To install `jq` on your 
+system, please see [here](https://github.com/stedolan/jq/wiki/Installation).

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,14 @@
+# Get the JSON list of IP Addresses from Bitbucket.
+data "http" "bitbucket_ips" {
+  url = "https://ip-ranges.atlassian.com/"
+
+  request_headers = {
+    "Accept" = "application/json"
+  }
+}
+
+# Format response to separate IPv4 and IPv6.
+data "external" "ip_addresses" {
+  program = ["bash", "-c", "echo '${data.http.bitbucket_ips.body}' | jq '{ipv4:[.items[]|select(.cidr|contains(\":\")|not).cidr]|join(\",\"),ipv6:[.items[]|select(.cidr|contains(\":\")).cidr]|join(\",\")}'"]
+}
+

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,9 @@
+output "ipv4_ip_addresses" {
+  description = "A list of IPv4 Addresses for outbound connections from Bitbucket's services."
+  value       = split(",", data.external.ip_addresses.result.ipv4)
+}
+
+output "ipv6_ip_addresses" {
+  description = "A list of IPv6 Addresses for outbound connections from Bitbucket's services."
+  value       = split(",", data.external.ip_addresses.result.ipv6)
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Looks up the Bitbucket Whitelist IP Addresses and exposes them as two separate lists for IPv4 and IPv6.