### PR TITLE
Drop external dependencies on bash and jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,57 @@
 # Bitbucket Whitelist IP Addresses
 
 This module provides both an IPv4 and IPv6 list of IP Addresses from Bitbucket, useful for whitelisting and security
-groups. In order to use this module, you must have both `bash` and `jq` installed on the system running Terraform.
+groups.
 
-For a JSON list of these ip addresses, see [here](https://ip-ranges.atlassian.com/).
+## Example usages
 
-### Installing JQ
+### AWS Security group
 
-This module uses `jq` for parsing the JSON response from Bitbucket's ip-range endpoint.  To install `jq` on your 
-system, please see [here](https://github.com/stedolan/jq/wiki/Installation).
+```
+module "bitbucket_ips" {
+  source = "terra-mod/ip-addresses/bitbucket"
+}
+
+resource "aws_security_group" "example" {
+  name        = "example"
+  description = "Example security group"
+
+  ingress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = module.bitbucket_ips.ipv4_range
+    ipv6_cidr_blocks = module.bitbucket_ips.ipv6_range
+    description      = "Webhooks from Atlassian public IP range"
+  }
+}
+```
+
+### AWS Policy
+
+```
+module "bitbucket_ips" {
+  source = "terra-mod/ip-addresses/bitbucket"
+}
+
+data "aws_iam_policy_document" "example" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::XXXXXXXXXXXX:oidc-provider/api.bitbucket.org/2.0/workspaces/mywspace/pipelines-config/identity/oidc"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "api.bitbucket.org/2.0/workspaces/mywspace/pipelines-config/identity/oidc:aud"
+      values   = ["ari:cloud:bitbucket::workspace/mywspace_uuid"]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = module.bitbucket_ips.ipv4_range
+    }
+  }
+}
+```

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,14 @@ data "http" "bitbucket_ips" {
   }
 }
 
-# Format response to separate IPv4 and IPv6.
-data "external" "ip_addresses" {
-  program = ["bash", "-c", "echo '${data.http.bitbucket_ips.body}' | jq '{ipv4:[.items[]|select(.cidr|contains(\":\")|not).cidr]|join(\",\"),ipv6:[.items[]|select(.cidr|contains(\":\")).cidr]|join(\",\")}'"]
+locals {
+  ip_range = tolist(jsondecode(data.http.bitbucket_ips.body).items[*].cidr)
+  ipv4_range = compact([
+    for cidr in local.ip_range :
+    replace(cidr, "/.*[:].*/", "")
+  ])
+  ipv6_range = compact([
+    for cidr in local.ip_range :
+    replace(cidr, "/.*[.].*/", "")
+  ])
 }
-

--- a/output.tf
+++ b/output.tf
@@ -1,9 +1,24 @@
-output "ipv4_ip_addresses" {
+output "ip_range" {
+  description = "A list of IPv4 and IPv6 Addresses for outbound connections from Bitbucket's services."
+  value       = local.ip_range
+}
+
+output "ipv4_range" {
   description = "A list of IPv4 Addresses for outbound connections from Bitbucket's services."
-  value       = split(",", data.external.ip_addresses.result.ipv4)
+  value       = local.ipv4_range
+}
+
+output "ipv6_range" {
+  description = "A list of IPv6 Addresses for outbound connections from Bitbucket's services."
+  value       = local.ipv6_range
+}
+
+output "ipv4_ip_addresses" {
+  description = "Alias to ipv4_range"
+  value       = local.ipv4_range
 }
 
 output "ipv6_ip_addresses" {
-  description = "A list of IPv6 Addresses for outbound connections from Bitbucket's services."
-  value       = split(",", data.external.ip_addresses.result.ipv6)
+  description = "Alias to ipv6_range"
+  value       = local.ipv6_range
 }


### PR DESCRIPTION
The ip-ranges.atlassian.com json response can be entirely
parsed with terraform builtin functions. This relies in the
fact that IPv4 and IPv6 addresses will either contain dots
or colons but never both.

This is very convenient for execution environments with limited
external tools, like the very hashicorp/terraform docker images.

Also document some interesting example usages.